### PR TITLE
Gradient clipping

### DIFF
--- a/examples/cfq/train.py
+++ b/examples/cfq/train.py
@@ -26,6 +26,7 @@ import matplotlib.pyplot as plt
 import functools
 import jax
 import jax.numpy as jnp
+from jax.experimental.optimizers import clip_grads
 
 import flax
 from flax import jax_utils
@@ -187,6 +188,7 @@ def train_step(optimizer: Any, batch: BatchType, rng: Any, vocab_size: int):
   (_, output), grad = grad_fn(optimizer.target)
   logits, predictions = output
   grad = jax.lax.pmean(grad, axis_name='batch')
+  grad = clip_grads(grad, max_norm=1.0)
   optimizer = optimizer.apply_gradient(grad)
   metrics = {}
   metrics = compute_metrics(logits,


### PR DESCRIPTION
With this changes gradient clipping is added to the training.

Before these changes the model was at some point having a sudden increase in loss and a drop to 0 for the accuracy (from which it would not recover). A potential cause for such behaviour would be exploding gradients, which can be treated with gradient clipping.

After these changes, even if the model still has some spikes in the training, they are smaller and there's no drop to 0 in the accuracy.