### PR TITLE
use correct keyword parameter names

### DIFF
--- a/examples/cfq/models.py
+++ b/examples/cfq/models.py
@@ -235,11 +235,12 @@ class Decoder(nn.Module):
       x = shared_embedding(x)
       x = nn.dropout(x, rate=embed_dropout_rate, deterministic=train)
       lstm_input = jnp.concatenate([x, prev_attention], axis=-1)
-      states, h = multilayer_lstm_cell(horizontal_dropout_masks=h_dropout_masks,
-                                       dropout_rate=vertical_dropout_rate,
-                                       input=lstm_input,
-                                       previous_states=previous_states,
-                                       train=train)
+      states, h = multilayer_lstm_cell(
+        horizontal_dropout_masks=h_dropout_masks,
+        vertical_dropout_rate=vertical_dropout_rate,
+        input=lstm_input,
+        previous_states=previous_states,
+        train=train)
       context = mlp_attention(jnp.expand_dims(h, 1), projected_keys,
                               encoder_hidden_states, attention_mask)
       context_and_state = jnp.concatenate([context, h], axis=-1)

--- a/examples/cfq/models_test.py
+++ b/examples/cfq/models_test.py
@@ -86,7 +86,7 @@ class ModelsTest(parameterized.TestCase):
       (states,
        y), _ = multilayer_lstm.init(nn.make_rng(),
                                     horizontal_dropout_masks=h_dropout_masks,
-                                    dropout_rate=dropout_rate,
+                                    vertical_dropout_rate=dropout_rate,
                                     input=input,
                                     previous_states=previous_states,
                                     train=False)


### PR DESCRIPTION
This change fixes bugs that have reached the master branch (some renamings resulted in errors which were not noticed before the merge)