### PR TITLE
Cfq ast

### DIFF
--- a/examples/cfq/syntax-based/action_sequence_test.py
+++ b/examples/cfq/syntax-based/action_sequence_test.py
@@ -1,0 +1,47 @@
+# Copyright 2020 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Module with integration tests for gemerating/applying action sequences."""
+from absl.testing import absltest
+from absl.testing import parameterized
+from grammar import Grammar, GRAMMAR_STR
+from asg import generate_action_sequence
+from node import apply_sequence_of_actions, traverse_tree
+
+class ActionSequenceTest(parameterized.TestCase):
+
+  def test_action_sequence(self):
+      """Test that when going query -> sequence of actions -> tree -> query2
+      the input and output query are equal (query, query2)."""
+      query = """SELECT count(*) WHERE {
+                 ?x0 ns:film.cinematographer.film ?x1 .
+                 ?x0 ns:film.writer.film ?x1 .
+                 ?x1 a ns:film.film .
+                 ?x2 ns:film.film_costumer_designer.costume_design_for_film M1 .
+                 M2 ns:film.film.starring/ns:film.performance.actor ?x0 .
+                 M2 ns:film.film.starring/ns:film.performance.actor ?x2
+              }"""
+      no_extra_spaces_query = " ".join(query.split())
+      grammar = Grammar(GRAMMAR_STR)
+      act_seq = generate_action_sequence(query, grammar)
+      root = apply_sequence_of_actions(act_seq, grammar)
+      generated_query = traverse_tree(root)
+      no_extra_spaces_generated_query =  " ".join(generated_query.split())
+      self.assertEqual(no_extra_spaces_query, no_extra_spaces_generated_query)
+       
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/examples/cfq/syntax-based/action_sequence_test.py
+++ b/examples/cfq/syntax-based/action_sequence_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Lint as: python3
-"""Module with integration tests for gemerating/applying action sequences."""
+"""Module with integration tests for generating/applying action sequences."""
 
 from absl.testing import absltest
 from absl.testing import parameterized

--- a/examples/cfq/syntax-based/action_sequence_test.py
+++ b/examples/cfq/syntax-based/action_sequence_test.py
@@ -41,8 +41,27 @@ class ActionSequenceTest(parameterized.TestCase):
     generated_query = traverse_tree(root)
     no_extra_spaces_generated_query =  " ".join(generated_query.split())
     self.assertEqual(no_extra_spaces_query, no_extra_spaces_generated_query)
-       
-
+     
+  def test_second_action_sequence(self):
+    """Test that when going query -> sequence of actions -> tree -> query2
+    the input and output query are equal (query, query2)."""
+    query = """SELECT count(*) WHERE {
+                ?x0 ns:film.director.film M0 .
+                ?x0 ns:influence.influence_node.influenced ?x1 .
+                ?x0 ns:influence.influence_node.influenced ?x2 .
+                ?x0 ns:influence.influence_node.influenced ?x3 .
+                ?x1 a ns:film.writer .
+                ?x2 ns:organization.organization_founder.organizations_founded ?x4 .
+                ?x3 ns:film.writer.film M3 .
+                ?x4 a ns:film.production_company
+            }"""
+    no_extra_spaces_query = " ".join(query.split())
+    grammar = Grammar(GRAMMAR_STR)
+    act_seq = generate_action_sequence(query, grammar)
+    root = apply_sequence_of_actions(act_seq, grammar)
+    generated_query = traverse_tree(root)
+    no_extra_spaces_generated_query =  " ".join(generated_query.split())
+    self.assertEqual(no_extra_spaces_query, no_extra_spaces_generated_query)
 
 if __name__ == '__main__':
   absltest.main()

--- a/examples/cfq/syntax-based/action_sequence_test.py
+++ b/examples/cfq/syntax-based/action_sequence_test.py
@@ -14,6 +14,7 @@
 
 # Lint as: python3
 """Module with integration tests for gemerating/applying action sequences."""
+
 from absl.testing import absltest
 from absl.testing import parameterized
 from grammar import Grammar, GRAMMAR_STR
@@ -23,23 +24,23 @@ from node import apply_sequence_of_actions, traverse_tree
 class ActionSequenceTest(parameterized.TestCase):
 
   def test_action_sequence(self):
-      """Test that when going query -> sequence of actions -> tree -> query2
-      the input and output query are equal (query, query2)."""
-      query = """SELECT count(*) WHERE {
+    """Test that when going query -> sequence of actions -> tree -> query2
+    the input and output query are equal (query, query2)."""
+    query = """SELECT count(*) WHERE {
                  ?x0 ns:film.cinematographer.film ?x1 .
                  ?x0 ns:film.writer.film ?x1 .
                  ?x1 a ns:film.film .
                  ?x2 ns:film.film_costumer_designer.costume_design_for_film M1 .
                  M2 ns:film.film.starring/ns:film.performance.actor ?x0 .
                  M2 ns:film.film.starring/ns:film.performance.actor ?x2
-              }"""
-      no_extra_spaces_query = " ".join(query.split())
-      grammar = Grammar(GRAMMAR_STR)
-      act_seq = generate_action_sequence(query, grammar)
-      root = apply_sequence_of_actions(act_seq, grammar)
-      generated_query = traverse_tree(root)
-      no_extra_spaces_generated_query =  " ".join(generated_query.split())
-      self.assertEqual(no_extra_spaces_query, no_extra_spaces_generated_query)
+               }"""
+    no_extra_spaces_query = " ".join(query.split())
+    grammar = Grammar(GRAMMAR_STR)
+    act_seq = generate_action_sequence(query, grammar)
+    root = apply_sequence_of_actions(act_seq, grammar)
+    generated_query = traverse_tree(root)
+    no_extra_spaces_generated_query =  " ".join(generated_query.split())
+    self.assertEqual(no_extra_spaces_query, no_extra_spaces_generated_query)
        
 
 

--- a/examples/cfq/syntax-based/asg.py
+++ b/examples/cfq/syntax-based/asg.py
@@ -65,7 +65,7 @@ def var_token_rule(substring, grammar):
     action_sequence = [apply_rule_act(grammar, 'var_token', 0)]
     action_sequence += [apply_rule_act(grammar, 'VAR', int(digit))]
   else:
-    # TOKEN brancg
+    # TOKEN branch
     action_sequence = [apply_rule_act(grammar, 'var_token', 1),
                        generate_act(substring)]
   return action_sequence

--- a/examples/cfq/syntax-based/asg.py
+++ b/examples/cfq/syntax-based/asg.py
@@ -1,3 +1,18 @@
+# Copyright 2020 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
 import re
 from typing import Tuple
 

--- a/examples/cfq/syntax-based/asg.py
+++ b/examples/cfq/syntax-based/asg.py
@@ -29,25 +29,6 @@ def generate_act(token):
     return (GENERATE_TOKEN, token)
 
 
-def var_rule(substring, grammar):
-  """
-  Rules:
-    VAR: "?x" DIGIT
-    DIGIT: /\d+/
-  Args:
-    substring: query substring to be matched by VAR
-    grammar: grammar object
-  """
-  action_sequence = [apply_rule_act(grammar, 'VAR', 0)]
-  match = re.match(r"\?x(\d+)", substring)
-  if match:
-      digit = match.groups()[0]
-      action_sequence.append(generate_act(digit))
-  else:
-    raise Exception('var rule not matched')
-  return action_sequence
-
-
 def select_clause_rule(substring, grammar):
   """
   Rules:
@@ -77,10 +58,12 @@ def var_token_rule(substring, grammar):
     substring: query substring to be matched by select_clause (without "SELECT")
     grammar: grammar object
   """
-  if re.match(r"\?x(\d+)", substring):
+  match = re.match(r"\?x(\d+)", substring)
+  if match:
     # VAR branch
+    digit = match.groups()[0]
     action_sequence = [apply_rule_act(grammar, 'var_token', 0)]
-    action_sequence += var_rule(substring, grammar)
+    action_sequence += [apply_rule_act(grammar, 'VAR', int(digit))]
   else:
     # TOKEN brancg
     action_sequence = [apply_rule_act(grammar, 'var_token', 1),

--- a/examples/cfq/syntax-based/asg.py
+++ b/examples/cfq/syntax-based/asg.py
@@ -1,5 +1,7 @@
 import re
+from typing import Tuple
 
+Action = Tuple[int, str]
 APPLY_RULE = 0
 GENERATE_TOKEN = 1
 

--- a/examples/cfq/syntax-based/asg_test.py
+++ b/examples/cfq/syntax-based/asg_test.py
@@ -1,3 +1,19 @@
+# Copyright 2020 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Module for unit tests for asg.py"""
 from absl.testing import absltest
 from absl.testing import parameterized
 from asg import apply_rule_act, generate_act, generate_action_sequence

--- a/examples/cfq/syntax-based/asg_test.py
+++ b/examples/cfq/syntax-based/asg_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Lint as: python3
-"""Module for unit tests for asg.py"""
+"""Module for unit tests for asg.py."""
 from absl.testing import absltest
 from absl.testing import parameterized
 from asg import apply_rule_act, generate_act, generate_action_sequence

--- a/examples/cfq/syntax-based/grammar.py
+++ b/examples/cfq/syntax-based/grammar.py
@@ -68,10 +68,13 @@ class Grammar:
     self.rules_by_head = generate_rules_by_head(self.sub_rules)
 
   def get_rule_by_head(self, head, index):
+    """Returns a tuple of (rule_name, rule_body) given the head, for e.g.
+    (r0,select_query)"""
     head_rules = self.rules_by_head[head]
     return head_rules[index]
 
   def get_rule_name_by_head(self, head, index):
+    "Returns the name of the rule (eg. r0) for the given head and index."
     return self.rules_by_head[head][index][0]
 
 if __name__ == "__main__":

--- a/examples/cfq/syntax-based/grammar.py
+++ b/examples/cfq/syntax-based/grammar.py
@@ -29,7 +29,7 @@ def generate_sub_rules(rule: str):
   match = re.match(r'(.*): (.*)', rule)
   if match:
     (head, body) = match.groups()
-    branches = re.split(r' | ', body)
+    branches = re.split(r' \| ', body)
     for branch in branches:
       sub_rules.append((head, branch.strip()))
   return sub_rules

--- a/examples/cfq/syntax-based/grammar.py
+++ b/examples/cfq/syntax-based/grammar.py
@@ -101,11 +101,3 @@ class Grammar:
   def get_rule_name_by_head(self, head: str, index: int):
     "Returns the name of the rule (eg. r0) for the given head and index."
     return self.get_rule_by_head(head, index)[0]
-
-if __name__ == "__main__":
-  grammar = Grammar(GRAMMAR_STR)
-  sub_rules = grammar.sub_rules
-  print(sub_rules)
-  for rule, branches in grammar.rules_by_head.items():
-    print(rule)
-    print(branches)

--- a/examples/cfq/syntax-based/grammar.py
+++ b/examples/cfq/syntax-based/grammar.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Lint as: python3
-"""Module for gramamr definition and parsing."""
+"""Module for grammar definition and parsing."""
 import re
 import collections
 from typing import Dict
@@ -94,7 +94,7 @@ class Grammar:
 
   def get_rule_by_head(self, head: str, index: int):
     """Returns a tuple of (rule_name, rule_body) given the head, for e.g.
-    (r0,select_query)"""
+    (r0, select_query)"""
     head_rules = self.rules_by_head[head]
     return head_rules[index]
 

--- a/examples/cfq/syntax-based/grammar.py
+++ b/examples/cfq/syntax-based/grammar.py
@@ -77,10 +77,13 @@ class Grammar:
     self.rules_by_head = generate_rules_by_head(self.sub_rules)
 
   def get_rule_by_head(self, head: str, index: int):
+    """Returns a tuple of (rule_name, rule_body) given the head, for e.g.
+    (r0,select_query)"""
     head_rules = self.rules_by_head[head]
     return head_rules[index]
 
   def get_rule_name_by_head(self, head: str, index: int):
+    "Returns the name of the rule (eg. r0) for the given head and index."
     return self.get_rule_by_head(head, index)[0]
 
 if __name__ == "__main__":

--- a/examples/cfq/syntax-based/grammar.py
+++ b/examples/cfq/syntax-based/grammar.py
@@ -1,3 +1,19 @@
+# Copyright 2020 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Module for gramamr definition and parsing."""
 import re
 import collections
 from typing import Dict

--- a/examples/cfq/syntax-based/grammar.py
+++ b/examples/cfq/syntax-based/grammar.py
@@ -31,8 +31,7 @@ GRAMMAR_STR = """
   triples_block: var_token TOKEN var_token
   var_token: VAR
            | TOKEN 
-  VAR: "?x" DIGIT 
-  DIGIT: /\d+/
+  VAR: "?x0" | "?x1" | "?x2" | "?x3" | "?x4" | "?x5"
   TOKEN: /[^\s]+/
 """
 

--- a/examples/cfq/syntax-based/grammar_test.py
+++ b/examples/cfq/syntax-based/grammar_test.py
@@ -16,7 +16,7 @@
 """Module with unit tests for grammar.py"""
 from absl.testing import absltest
 from absl.testing import parameterized
-from grammar import generate_grammar
+from grammar import generate_grammar, Grammar
 
 
 class GrammarTest(parameterized.TestCase):
@@ -58,6 +58,29 @@ class GrammarTest(parameterized.TestCase):
       'r14': ('TOKEN', '/[^\\s]+/')
     }
     self.assertEqual(grammar_dict, expected_grammar_dict)
+
+  def test_Grammar(self):
+    grammar_str = """
+      a: b
+      b: c | d
+      c: "some_token"
+      d: "some_other_token"
+    """
+    grammar = Grammar(grammar_str)
+    expected_sub_rules = {
+      'r0': ('a', 'b'),
+      'r1': ('b', 'c'),
+      'r2': ('b', 'd'),
+      'r3': ('c', '"some_token"'),
+      'r4': ('d', '"some_other_token"')}
+    expected_rules_by_head = {
+      'a': [('r0', 'b')],
+      'b': [('r1', 'c'), ('r2', 'd')],
+      'c': [('r3', '"some_token"')],
+      'd': [('r4', '"some_other_token"')]}
+    self.assertEqual(grammar.sub_rules, expected_sub_rules)
+    self.assertEqual(grammar.rules_by_head, expected_rules_by_head)
+    
 
 if __name__ == '__main__':
   absltest.main()

--- a/examples/cfq/syntax-based/grammar_test.py
+++ b/examples/cfq/syntax-based/grammar_test.py
@@ -35,8 +35,7 @@ class GrammarTest(parameterized.TestCase):
       triples_block: var_token TOKEN var_token
       var_token: VAR
                 | TOKEN 
-      VAR: "?x" DIGIT 
-      DIGIT: /\d+/
+      VAR: "?x0" | "?x1" | "?x2" | "?x3" | "?x4" | "?x5" 
       TOKEN: /[^\s]+/
     """
     grammar_dict = generate_grammar(grammar_str)
@@ -53,9 +52,13 @@ class GrammarTest(parameterized.TestCase):
       'r9': ('triples_block', 'var_token TOKEN var_token'),
       'r10': ('var_token', 'VAR'),
       'r11': ('var_token', 'TOKEN'),
-      'r12': ('VAR', '"?x" DIGIT'),
-      'r13': ('DIGIT', '/\\d+/'),
-      'r14': ('TOKEN', '/[^\\s]+/')
+      'r12': ('VAR', '"?x0"'),
+      'r13': ('VAR', '"?x1"'),
+      'r14': ('VAR', '"?x2"'),
+      'r15': ('VAR', '"?x3"'),
+      'r16': ('VAR', '"?x4"'),
+      'r17': ('VAR', '"?x5"'),
+      'r18': ('TOKEN', '/[^\\s]+/')
     }
     self.assertEqual(grammar_dict, expected_grammar_dict)
 

--- a/examples/cfq/syntax-based/grammar_test.py
+++ b/examples/cfq/syntax-based/grammar_test.py
@@ -80,7 +80,7 @@ class GrammarTest(parameterized.TestCase):
       'd': [('r4', '"some_other_token"')]}
     self.assertEqual(grammar.sub_rules, expected_sub_rules)
     self.assertEqual(grammar.rules_by_head, expected_rules_by_head)
-    
+ 
 
 if __name__ == '__main__':
   absltest.main()

--- a/examples/cfq/syntax-based/grammar_test.py
+++ b/examples/cfq/syntax-based/grammar_test.py
@@ -1,3 +1,19 @@
+# Copyright 2020 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Module with unit tests for grammar.py"""
 from absl.testing import absltest
 from absl.testing import parameterized
 from grammar import generate_grammar

--- a/examples/cfq/syntax-based/grammar_test.py
+++ b/examples/cfq/syntax-based/grammar_test.py
@@ -1,0 +1,47 @@
+from absl.testing import absltest
+from absl.testing import parameterized
+from grammar import generate_grammar
+
+
+class GrammarTest(parameterized.TestCase):
+
+  def test_generate_grammar(self):
+    grammar_str = """
+      query: select_query
+      select_query: select_clause "WHERE" "{" where_clause "}"
+      select_clause: "SELECT" "DISTINCT" "?x0"
+                    | "SELECT" "count(*)"     
+      where_clause: where_entry 
+                    | where_clause "." where_entry
+      where_entry: triples_block
+                    | filter_clause
+      filter_clause: "FILTER" "(" var_token "!=" var_token ")"
+      triples_block: var_token TOKEN var_token
+      var_token: VAR
+                | TOKEN 
+      VAR: "?x" DIGIT 
+      DIGIT: /\d+/
+      TOKEN: /[^\s]+/
+    """
+    grammar_dict = generate_grammar(grammar_str)
+    expected_grammar_dict = {
+      'r0': ('query', 'select_query'),
+      'r1': ('select_query', 'select_clause "WHERE" "{" where_clause "}"'),
+      'r2': ('select_clause', '"SELECT" "DISTINCT" "?x0"'),
+      'r3': ('select_clause', '"SELECT" "count(*)"'),
+      'r4': ('where_clause', 'where_entry'),
+      'r5': ('where_clause', 'where_clause "." where_entry'),
+      'r6': ('where_entry', 'triples_block'),
+      'r7': ('where_entry', 'filter_clause'),
+      'r8': ('filter_clause', '"FILTER" "(" var_token "!=" var_token ")"'),
+      'r9': ('triples_block', 'var_token TOKEN var_token'),
+      'r10': ('var_token', 'VAR'),
+      'r11': ('var_token', 'TOKEN'),
+      'r12': ('VAR', '"?x" DIGIT'),
+      'r13': ('DIGIT', '/\\d+/'),
+      'r14': ('TOKEN', '/[^\\s]+/')
+    }
+    self.assertEqual(grammar_dict, expected_grammar_dict)
+
+if __name__ == '__main__':
+  absltest.main()

--- a/examples/cfq/syntax-based/grammar_test.py
+++ b/examples/cfq/syntax-based/grammar_test.py
@@ -80,7 +80,7 @@ class GrammarTest(parameterized.TestCase):
       'd': [('r4', '"some_other_token"')]}
     self.assertEqual(grammar.sub_rules, expected_sub_rules)
     self.assertEqual(grammar.rules_by_head, expected_rules_by_head)
- 
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/examples/cfq/syntax-based/node.py
+++ b/examples/cfq/syntax-based/node.py
@@ -69,6 +69,8 @@ def apply_action(frontier_nodes_stack: deque, action: Action, grammar: Grammar):
 
 
 def apply_first_action(action: Action, grammar: Grammar):
+  """Applies the first action in the sequence of actions and constructs the
+  tree root."""
   action_type, action_value = action
   if action_type != APPLY_RULE:
     raise Exception('First action should be rule application')
@@ -78,6 +80,7 @@ def apply_first_action(action: Action, grammar: Grammar):
 
 
 def apply_sequence_of_actions(action_sequence: List, grammar: Grammar):
+  """Applies a sequence of actions to construct a syntax tree."""
   root = apply_first_action(action_sequence[0], grammar)
   frontier_nodes = deque()
   frontier_nodes.append(root)

--- a/examples/cfq/syntax-based/node.py
+++ b/examples/cfq/syntax-based/node.py
@@ -14,6 +14,7 @@
 
 # Lint as: python3
 """This module is for constructing the syntax tree from the action sequence."""
+
 import re
 from typing import List
 from grammar import Grammar, GRAMMAR_STR
@@ -48,7 +49,7 @@ def apply_action(frontier_nodes_stack: deque, action: Action, grammar: Grammar):
     head, body = grammar.sub_rules[rule_name]
     if head != current_node.value:
       raise Exception('Invalid action. Got {} and expected {}'.format(
-        head, current_node.value))
+          head, current_node.value))
     rule_tokens = body.split()
     for rule_token in rule_tokens:
       match = re.match(r'\"(.*)\"', rule_token)
@@ -66,6 +67,7 @@ def apply_action(frontier_nodes_stack: deque, action: Action, grammar: Grammar):
     frontier_nodes_stack.extend(new_frontier_nodes)
   return frontier_nodes_stack
 
+
 def apply_first_action(action: Action, grammar: Grammar):
   action_type, action_value = action
   if action_type != APPLY_RULE:
@@ -74,6 +76,7 @@ def apply_first_action(action: Action, grammar: Grammar):
   root = Node(None, node_value)
   return root
 
+
 def apply_sequence_of_actions(action_sequence: List, grammar: Grammar):
   root = apply_first_action(action_sequence[0], grammar)
   frontier_nodes = deque()
@@ -81,6 +84,7 @@ def apply_sequence_of_actions(action_sequence: List, grammar: Grammar):
   for action in action_sequence[1:]:
     frontier_nodes = apply_action(frontier_nodes, action, grammar)
   return root
+
 
 def traverse_tree(root: Node):
   """DFS raversal of tree. The result of the traversal should be the query. In
@@ -99,7 +103,8 @@ def traverse_tree(root: Node):
     delimiter = ' '
   return delimiter.join(children_substrings)
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
   query = """SELECT DISTINCT ?x0 WHERE {
       ?x0 a people.person .
       ?x0 influence.influencenode.influencedby ?x1 .
@@ -109,6 +114,3 @@ if __name__=="__main__":
   root = apply_sequence_of_actions(generated_action_sequence, grammar)
   query = traverse_tree(root)
   print(query)
-
-
-    

--- a/examples/cfq/syntax-based/node.py
+++ b/examples/cfq/syntax-based/node.py
@@ -32,6 +32,8 @@ class Node:
   def add_child(self, child: 'Node'):
     self.children.append(child)
 
+  def __repr__(self):
+    return self.value
 
 def apply_action(frontier_nodes_stack: deque, action: Action, grammar: Grammar):
   """Applies an action (apply rule or generate token). The action extends an

--- a/examples/cfq/syntax-based/node.py
+++ b/examples/cfq/syntax-based/node.py
@@ -1,4 +1,19 @@
-"""This module is for action sequence -> query"""
+# Copyright 2020 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""This module is for constructing the syntax tree from the action sequence."""
 import re
 from typing import List
 from grammar import Grammar, GRAMMAR_STR

--- a/examples/cfq/syntax-based/node.py
+++ b/examples/cfq/syntax-based/node.py
@@ -34,7 +34,7 @@ class Node:
 
 
 def apply_action(frontier_nodes_stack: deque, action: Action, grammar: Grammar):
-  """Applies an action (apply rule or generate token). The action extends a
+  """Applies an action (apply rule or generate token). The action extends an
   AST that is under construction by extending the stack of frontier nodes.
   The function returns the extended stack."""
   current_node: Node = frontier_nodes_stack.pop()
@@ -45,8 +45,7 @@ def apply_action(frontier_nodes_stack: deque, action: Action, grammar: Grammar):
     current_node.add_child(child)
   else:
     new_frontier_nodes = []
-    rule_name = action_value
-    head, body = grammar.sub_rules[rule_name]
+    head, body = grammar.sub_rules[action_value]
     if head != current_node.value:
       raise Exception('Invalid action. Got {} and expected {}'.format(
           head, current_node.value))
@@ -57,12 +56,11 @@ def apply_action(frontier_nodes_stack: deque, action: Action, grammar: Grammar):
         # Create a leaf node with a token from the rule (e.g. SELECT).
         node_value = match.groups()[0]
         child = Node(current_node, node_value)
-        current_node.add_child(child)
       else:
         # Create new frontier node.
         child = Node(current_node, rule_token)
-        current_node.add_child(child)
         new_frontier_nodes.append(child)
+      current_node.add_child(child)
     new_frontier_nodes.reverse()
     frontier_nodes_stack.extend(new_frontier_nodes)
   return frontier_nodes_stack
@@ -90,7 +88,7 @@ def apply_sequence_of_actions(action_sequence: List, grammar: Grammar):
 
 
 def traverse_tree(root: Node):
-  """DFS raversal of tree. The result of the traversal should be the query. In
+  """DFS traversal of tree. The result of the traversal should be the query. In
   case the parent node is a terminal, the descendents will be simply
   concatenated, e.g. VAR, otherwise the substrings are merged together by spaces.
   """

--- a/examples/cfq/syntax-based/node.py
+++ b/examples/cfq/syntax-based/node.py
@@ -1,0 +1,99 @@
+"""This module is for action sequence -> query"""
+import re
+from typing import List
+from grammar import Grammar, GRAMMAR_STR
+from asg import generate_action_sequence
+from collections import deque
+from asg import Action, APPLY_RULE, GENERATE_TOKEN
+
+class Node:
+
+  def __init__(self, parent: 'Node', value: str):
+    self.parent = parent
+    self.value = value
+    self.children = []
+
+  def add_child(self, child: 'Node'):
+    self.children.append(child)
+
+
+def apply_action(frontier_nodes_stack: deque, action: Action, grammar: Grammar):
+  """Applies an action (apply rule or generate token). The action extends a
+  AST that is under construction by extending the stack of frontier nodes.
+  The function returns the extended stack."""
+  current_node: Node = frontier_nodes_stack.pop()
+  action_type, action_value = action
+  if action_type == GENERATE_TOKEN:
+    # Generate leaf node with token stored in the action.
+    child = Node(current_node, action_value)
+    current_node.add_child(child)
+  else:
+    new_frontier_nodes = []
+    rule_name = action_value
+    head, body = grammar.sub_rules[rule_name]
+    if head != current_node.value:
+      raise Exception('Invalid action. Got {} and expected {}'.format(
+        head, current_node.value))
+    rule_tokens = body.split()
+    for rule_token in rule_tokens:
+      match = re.match(r'\"(.*)\"', rule_token)
+      if match:
+        # Create a leaf node with a token from the rule (e.g. SELECT).
+        node_value = match.groups()[0]
+        child = Node(current_node, node_value)
+        current_node.add_child(child)
+      else:
+        # Create new frontier node.
+        child = Node(current_node, rule_token)
+        current_node.add_child(child)
+        new_frontier_nodes.append(child)
+    new_frontier_nodes.reverse()
+    frontier_nodes_stack.extend(new_frontier_nodes)
+  return frontier_nodes_stack
+
+def apply_first_action(action: Action, grammar: Grammar):
+  action_type, action_value = action
+  if action_type != APPLY_RULE:
+    raise Exception('First action should be rule application')
+  _, node_value = grammar.sub_rules[action_value]
+  root = Node(None, node_value)
+  return root
+
+def apply_sequence_of_actions(action_sequence: List, grammar: Grammar):
+  root = apply_first_action(action_sequence[0], grammar)
+  frontier_nodes = deque()
+  frontier_nodes.append(root)
+  for action in action_sequence[1:]:
+    frontier_nodes = apply_action(frontier_nodes, action, grammar)
+  return root
+
+def traverse_tree(root: Node):
+  """DFS raversal of tree. The result of the traversal should be the query. In
+  case the parent node is a terminal, the descendents will be simply
+  concatenated, e.g. VAR, otherwise the substrings are merged together by spaces.
+  """
+  if len(root.children) == 0:
+    return root.value
+  children_substrings = []
+  for child in root.children:
+    child_substr = traverse_tree(child)
+    children_substrings.append(child_substr)
+  if root.value.isupper():
+    delimiter = ''
+  else:
+    delimiter = ' '
+  return delimiter.join(children_substrings)
+
+if __name__=="__main__":
+  query = """SELECT DISTINCT ?x0 WHERE {
+      ?x0 a people.person .
+      ?x0 influence.influencenode.influencedby ?x1 .
+      ?x1 film.actor.filmnsfilm.performance.character M1 }"""
+  grammar = Grammar(GRAMMAR_STR)
+  generated_action_sequence = generate_action_sequence(query, grammar)
+  root = apply_sequence_of_actions(generated_action_sequence, grammar)
+  query = traverse_tree(root)
+  print(query)
+
+
+    


### PR DESCRIPTION
This PR contains changes for generating the Syntax Tree ST) from the sequence of actions, as well as some small fixes & tests addition.
The functionality of generating a ST by applying the sequence of actions will be needed in the decoder on the inference flow. Even if the code up for merge now won't be used as it is, and small changes might occur, it has the basic functionality of constructing a tree through iterative action application.
It was implemented at this point to make sure that the sequence of actions was extracted correctly, that is, that if the sequence of actions is extracted from a query, the same query can be retrieved from the sequence of actions (which is covered in an integration test).