### PR TITLE
Cfq cst to ast

### DIFF
--- a/examples/cfq/syntax-based/action_sequence_test.py
+++ b/examples/cfq/syntax-based/action_sequence_test.py
@@ -19,7 +19,7 @@ from absl.testing import absltest
 from absl.testing import parameterized
 from grammar import Grammar, GRAMMAR_STR
 from asg import generate_action_sequence
-from node import apply_sequence_of_actions, traverse_tree
+from node import apply_sequence_of_actions, extract_query
 
 class ActionSequenceTest(parameterized.TestCase):
 
@@ -38,7 +38,7 @@ class ActionSequenceTest(parameterized.TestCase):
     grammar = Grammar(GRAMMAR_STR)
     act_seq = generate_action_sequence(query, grammar)
     root = apply_sequence_of_actions(act_seq, grammar)
-    generated_query = traverse_tree(root)
+    generated_query = extract_query(root, grammar)
     no_extra_spaces_generated_query =  " ".join(generated_query.split())
     self.assertEqual(no_extra_spaces_query, no_extra_spaces_generated_query)
      
@@ -59,7 +59,7 @@ class ActionSequenceTest(parameterized.TestCase):
     grammar = Grammar(GRAMMAR_STR)
     act_seq = generate_action_sequence(query, grammar)
     root = apply_sequence_of_actions(act_seq, grammar)
-    generated_query = traverse_tree(root)
+    generated_query = extract_query(root, grammar)
     no_extra_spaces_generated_query =  " ".join(generated_query.split())
     self.assertEqual(no_extra_spaces_query, no_extra_spaces_generated_query)
 

--- a/examples/cfq/syntax-based/asg.py
+++ b/examples/cfq/syntax-based/asg.py
@@ -14,15 +14,15 @@
 
 # Lint as: python3
 import re
-from typing import Tuple
+from typing import Tuple, Union
 
-Action = Tuple[int, str]
+Action = Tuple[int, Union[str, int]]
 APPLY_RULE = 0
 GENERATE_TOKEN = 1
 
 
 def apply_rule_act(grammar, head, index):
-  return (APPLY_RULE, grammar.get_rule_name_by_head(head, index))
+  return (APPLY_RULE, grammar.get_branch_id_by_head_and_index(head, index))
 
 
 def generate_act(token):
@@ -69,7 +69,7 @@ def var_token_rule(substring, grammar):
     action_sequence = [apply_rule_act(grammar, 'var_token', 1),
                        generate_act(substring)]
   return action_sequence
-  
+
 
 def where_entry_rule(substring, grammar):
   """

--- a/examples/cfq/syntax-based/asg_test.py
+++ b/examples/cfq/syntax-based/asg_test.py
@@ -44,32 +44,32 @@ class AsgTest(parameterized.TestCase):
     grammar = Grammar(grammar_str)
     generated_action_sequence = generate_action_sequence(query, grammar)
     expected_action_sequence = [
-      (0, 0),
-      (0, 1),
-      (0, 2),
-      (0, 5),
-      (0, 5),
-      (0, 4),
-      (0, 6),
-      (0, 7),
-      (0, 8),
-      (0, 10),
+      (0, 0), # query -> select_query
+      (0, 1), # select_query -> select_clause "WHERE" "{" where_clause "}"
+      (0, 2), # select_clause -> "SELECT" "DISTINCT" "?x0"
+      (0, 5), # where_clause -> where_clause "." where_entry
+      (0, 5), # where_clause -> where_clause "." where_entry
+      (0, 4), # where_clause -> where_entry
+      (0, 6), # where_entry -> triples_block
+      (0, 7), # triples_block -> var_token TOKEN var_token
+      (0, 8), # var_token -> VAR
+      (0, 10), # VAR -> "?x0"
       (1, 'a'),
-      (0, 9),
+      (0, 9), # var_token -> TOKEN
       (1, 'people.person'),
-      (0, 6),
-      (0, 7),
-      (0, 8),
-      (0, 10),
+      (0, 6), # where_entry -> triples_block
+      (0, 7), # triples_block -> var_token TOKEN var_token
+      (0, 8), # var_token -> VAR
+      (0, 10), # VAR -> "?x0"
       (1, 'influence.influencenode.influencedby'),
-      (0, 8),
-      (0, 11),
-      (0, 6),
-      (0, 7),
-      (0, 8),
-      (0, 11),
+      (0, 8), # var_token -> VAR
+      (0, 11), # VAR -> "?x1"
+      (0, 6), # where_entry -> triples_block
+      (0, 7), # triples_block -> var_token TOKEN var_token
+      (0, 8), # var_token -> VAR
+      (0, 11), # VAR -> "?x1"
       (1, 'film.actor.filmnsfilm.performance.character'),
-      (0, 9),
+      (0, 9), # var_token -> TOKEN
       (1, 'M1')
     ]
     self.assertEqual(generated_action_sequence, expected_action_sequence)
@@ -101,39 +101,39 @@ class AsgTest(parameterized.TestCase):
     grammar = Grammar(grammar_str)
     generated_action_sequence = generate_action_sequence(query, grammar)
     expected_action_sequence = [
-      (0, 0),
-      (0, 1),
-      (0, 3),
-      (0, 5),
-      (0, 5),
-      (0, 5),
-      (0, 4),
-      (0, 6),
-      (0, 9),
-      (0, 10),
-      (0, 12),
+      (0, 0), # query -> select_query
+      (0, 1), # select_query -> select_clause "WHERE" "{" where_clause "}"
+      (0, 3), # select_clause -> "SELECT" "count(*)"
+      (0, 5), # where_clause -> where_clause "." where_entry
+      (0, 5), # where_clause -> where_clause "." where_entry
+      (0, 5), # where_clause -> where_clause "." where_entry
+      (0, 4), # where_clause -> where_entry
+      (0, 6), # where_entry -> triples_block
+      (0, 9), # triples_block -> var_token TOKEN var_token
+      (0, 10), # var_token -> VAR
+      (0, 12), # VAR -> "?x0"
       (1, 'a'),
-      (0, 11),
+      (0, 11), # var_token -> TOKEN
       (1, 'film.editor'),
-      (0, 6),
-      (0, 9),
-      (0, 10),
-      (0, 12),
+      (0, 6), # where_entry -> triples_block
+      (0, 9), # triples_block -> var_token TOKEN var_token
+      (0, 10), # var_token -> VAR
+      (0, 12), # VAR -> "?x0"
       (1, 'influence.influence_node.influenced_by'),
-      (0, 10),
-      (0, 13),
-      (0, 6),
-      (0, 9),
-      (0, 10),
-      (0, 13),
+      (0, 10), # var_token -> VAR
+      (0, 13), # VAR -> "?x1"
+      (0, 6), # where_entry -> triples_block
+      (0, 9), # triples_block -> var_token TOKEN var_token
+      (0, 10), # var_token -> VAR
+      (0, 13), # VAR -> "?x1"
       (1, 'simplified_token'),
-      (0, 11),
+      (0, 11), # var_token -> TOKEN
       (1, 'M1'),
-      (0, 7),
-      (0, 8),
-      (0, 10),
-      (0, 13),
-      (0, 11),
+      (0, 7), # where_entry -> filter_clause
+      (0, 8), # filter_clause -> "FILTER" "(" var_token "!=" var_token ")"
+      (0, 10), # var_token -> VAR
+      (0, 13), # VAR -> "?x1"
+      (0, 11), # var_token -> TOKEN
       (1, 'M1')
     ]
     self.assertEqual(generated_action_sequence, expected_action_sequence)

--- a/examples/cfq/syntax-based/asg_test.py
+++ b/examples/cfq/syntax-based/asg_test.py
@@ -34,8 +34,7 @@ class AsgTest(parameterized.TestCase):
       triples_block: var_token TOKEN var_token
       var_token: VAR
               | TOKEN 
-      VAR: "?x" DIGIT 
-      DIGIT: /\d+/
+      VAR: "?x0" | "?x1" | "?x2" | "?x3" | "?x4" | "?x5"
       TOKEN: /[^\s]+/
     """
     query = """SELECT DISTINCT ?x0 WHERE {
@@ -45,35 +44,34 @@ class AsgTest(parameterized.TestCase):
     grammar = Grammar(grammar_str)
     generated_action_sequence = generate_action_sequence(query, grammar)
     expected_action_sequence = [
-      (0, 'r0'),
-      (0, 'r1'),
-      (0, 'r6'),
-      (0, 'r13'),
-      (0, 'r13'),
-      (0, 'r12'),
-      (0, 'r17'),
-      (0, 'r18'),
-      (0, 'r21'),
-      (0, 'r24'),
-      (1, '0'),
+      (0, 0),
+      (0, 1),
+      (0, 2),
+      (0, 5),
+      (0, 5),
+      (0, 4),
+      (0, 6),
+      (0, 7),
+      (0, 8),
+      (0, 10),
       (1, 'a'),
-      (0, 'r22'),
+      (0, 9),
       (1, 'people.person'),
-      (0, 'r17'), (0, 'r18'),
-      (0, 'r21'), (0, 'r24'),
-      (1, '0'),
+      (0, 6),
+      (0, 7),
+      (0, 8),
+      (0, 10),
       (1, 'influence.influencenode.influencedby'),
-      (0, 'r21'),
-      (0, 'r24'),
-      (1, '1'),
-      (0, 'r17'),
-      (0, 'r18'),
-      (0, 'r21'),
-      (0, 'r24'),
-      (1, '1'),
+      (0, 8),
+      (0, 11),
+      (0, 6),
+      (0, 7),
+      (0, 8),
+      (0, 11),
       (1, 'film.actor.filmnsfilm.performance.character'),
-      (0, 'r22'),
-      (1, 'M1')]
+      (0, 9),
+      (1, 'M1')
+    ]
     self.assertEqual(generated_action_sequence, expected_action_sequence)
 
   def test_generate_action_sequence_filter(self):
@@ -90,8 +88,7 @@ class AsgTest(parameterized.TestCase):
       triples_block: var_token TOKEN var_token
       var_token: VAR
               | TOKEN 
-      VAR: "?x" DIGIT 
-      DIGIT: /\d+/
+      VAR: "?x0" | "?x1" | "?x2" | "?x3" | "?x4" | "?x5"
       TOKEN: /[^\s]+/
     """
     query = """SELECT count(*)  WHERE {
@@ -104,45 +101,41 @@ class AsgTest(parameterized.TestCase):
     grammar = Grammar(grammar_str)
     generated_action_sequence = generate_action_sequence(query, grammar)
     expected_action_sequence = [
-      (0, 'r0'),
-      (0, 'r1'),
-      (0, 'r7'),
-      (0, 'r13'),
-      (0, 'r13'),
-      (0, 'r13'),
-      (0, 'r12'),
-      (0, 'r17'),
-      (0, 'r26'),
-      (0, 'r29'),
-      (0, 'r32'),
-      (1, '0'),
+      (0, 0),
+      (0, 1),
+      (0, 3),
+      (0, 5),
+      (0, 5),
+      (0, 5),
+      (0, 4),
+      (0, 6),
+      (0, 9),
+      (0, 10),
+      (0, 12),
       (1, 'a'),
-      (0, 'r30'),
+      (0, 11),
       (1, 'film.editor'),
-      (0, 'r17'),
-      (0, 'r26'),
-      (0, 'r29'),
-      (0, 'r32'),
-      (1, '0'),
+      (0, 6),
+      (0, 9),
+      (0, 10),
+      (0, 12),
       (1, 'influence.influence_node.influenced_by'),
-      (0, 'r29'),
-      (0, 'r32'),
-      (1, '1'),
-      (0, 'r17'),
-      (0, 'r26'),
-      (0, 'r29'),
-      (0, 'r32'),
-      (1, '1'),
+      (0, 10),
+      (0, 13),
+      (0, 6),
+      (0, 9),
+      (0, 10),
+      (0, 13),
       (1, 'simplified_token'),
-      (0, 'r30'),
+      (0, 11),
       (1, 'M1'),
-      (0, 'r18'),
-      (0, 'r20'),
-      (0, 'r29'),
-      (0, 'r32'),
-      (1, '1'),
-      (0, 'r30'),
-      (1, 'M1')]
+      (0, 7),
+      (0, 8),
+      (0, 10),
+      (0, 13),
+      (0, 11),
+      (1, 'M1')
+    ]
     self.assertEqual(generated_action_sequence, expected_action_sequence)
 
 

--- a/examples/cfq/syntax-based/grammar.py
+++ b/examples/cfq/syntax-based/grammar.py
@@ -17,6 +17,7 @@
 import re
 import collections
 from typing import Dict, List
+from enum import Enum
 
 GRAMMAR_STR = """
   query: select_query
@@ -79,6 +80,11 @@ def extract_sub_rules(grammar_str: str):
     sub_rules += extract_sub_rules_from_rules(rule)
   return sub_rules
 
+class TermType(Enum):
+  SYNTAX_TERM = 0
+  REGEX_TERM = 1
+  RULE_TERM = 2
+
 class Term:
   """
   Class describing a term (token on the right side of a rule). It contains a
@@ -86,12 +92,8 @@ class Term:
   contains the string "SELECT", if the term is a regex term, it also contains a
   string, for eg. "/[^\s]+/", and if the term is a rule head, the head is stored.
   """
-  # TODO: enum
-  SYNTAX_TERM = 0
-  REGEX_TERM = 1
-  RULE_TERM = 2
 
-  def __init__(self, term_type: int, value: str):
+  def __init__(self, term_type: TermType, value: str):
     self.term_type = term_type
     self.value = value
 
@@ -117,16 +119,16 @@ class RuleBranch:
       if match:
         # Syntax token matched.
         syntax_token = match.groups()[0]
-        term = Term(Term.SYNTAX_TERM, syntax_token)
+        term = Term(TermType.SYNTAX_TERM, syntax_token)
       else:
         match = re.match(r'\/(.*)\/', body_token)
         if match:
           # Regex token matched.
           regex_token = match.groups()[0]
-          term = Term(Term.REGEX_TERM, regex_token)
+          term = Term(TermType.REGEX_TERM, regex_token)
         else:
           # Rule token => store rule head.
-          term = Term(Term.RULE_TERM, body_token)
+          term = Term(TermType.RULE_TERM, body_token)
       rule_terms.append(term)
     return rule_terms
 

--- a/examples/cfq/syntax-based/grammar.py
+++ b/examples/cfq/syntax-based/grammar.py
@@ -155,6 +155,8 @@ class Grammar:
       rule_branch = RuleBranch(id=branch_id, body_str=body)
       self.branches.append(rule_branch)
       self.rules[head].append(branch_id)
+    first_rule = sub_rules[0]
+    self.grammar_entry = first_rule[0]
 
   def get_branch_id_by_head_and_index(self, head: str, index: int):
     """Returns the branch id given the head and index"""
@@ -169,7 +171,4 @@ if __name__ == "__main__":
     print(branch)
   print('\nRules')
   print(grammar.rules)
-  
-        
-
 

--- a/examples/cfq/syntax-based/grammar.py
+++ b/examples/cfq/syntax-based/grammar.py
@@ -16,7 +16,7 @@
 """Module for grammar definition and parsing."""
 import re
 import collections
-from typing import Dict
+from typing import Dict, List
 
 GRAMMAR_STR = """
   query: select_query
@@ -38,7 +38,7 @@ GRAMMAR_STR = """
 def remove_multiple_spaces(s: str):
   return ' '.join(s.strip().split())
 
-def generate_sub_rules(rule: str):
+def extract_sub_rules_from_rules(rule: str):
   sub_rules = []
   rule = remove_multiple_spaces(rule)
   match = re.match(r'(.*): (.*)', rule)
@@ -50,15 +50,17 @@ def generate_sub_rules(rule: str):
   return sub_rules
 
 
-def generate_grammar(grammar_str: str):
+def extract_sub_rules(grammar_str: str):
   """
-  Method for generating the grammar from a string.
+  Method for extracting the sub rules (head -> branch) from a grammar string.
   The current logic assumes that each rule branch is on a separate line.
-  This is valid:
-  a : b
-    | c
-  This is not:
-  a : b | c
+  For the following grammar:
+  a -> b | c
+  b -> d
+  c -> "C"
+  d -> "D"
+  it would generate a list of tuples (head,branch):
+  [('a','b'), ('a','c'), ('c','"C"'), ('d','"D"')]
   """
   grammar_str = grammar_str.strip()
   split_lines = re.split('\n', grammar_str)
@@ -74,29 +76,98 @@ def generate_grammar(grammar_str: str):
     rules.append(current_rule)
   sub_rules = []
   for rule in rules:
-    sub_rules += generate_sub_rules(rule)
+    sub_rules += extract_sub_rules_from_rules(rule)
+  return sub_rules
 
-  sub_rules_dict = {f'r{i}': sub_rules[i] for i in range(len(sub_rules))}
-  return sub_rules_dict
+class Term:
+  """
+  Class describing a term (token on the right side of a rule). It contains a
+  type and a value. If the term is a syntax token, eg. "SELECT", the value
+  contains the string "SELECT", if the term is a regex term, it also contains a
+  string, for eg. "/[^\s]+/", and if the term is a rule head, the head is stored.
+  """
+  # TODO: enum
+  SYNTAX_TERM = 0
+  REGEX_TERM = 1
+  RULE_TERM = 2
 
-def generate_rules_by_head(sub_rules_dict: Dict):
-  result = collections.defaultdict(list)
-  for rule_name, (head, body) in sub_rules_dict.items():
-    result[head].append((rule_name, body))
-  return result
+  def __init__(self, term_type: int, value: str):
+    self.term_type = term_type
+    self.value = value
+
+  def __repr__(self):
+    return self.value
+
+  def __eq__(self, other):
+    """Overrides the default implementation"""
+    return self.term_type == other.term_type and self.value == other.value
+
+class RuleBranch:
+
+  def __init__(self, id: int, body_str: str):
+    self.branch_id = id
+    self.body = RuleBranch.construct_from_string(body_str)
+
+  @staticmethod
+  def construct_from_string(body: str):
+    rule_terms = []
+    body_tokens = body.split()
+    for body_token in body_tokens:
+      match = re.match(r'\"(.*)\"', body_token)
+      if match:
+        # Syntax token matched.
+        syntax_token = match.groups()[0]
+        term = Term(Term.SYNTAX_TERM, syntax_token)
+      else:
+        match = re.match(r'\/(.*)\/', body_token)
+        if match:
+          # Regex token matched.
+          regex_token = match.groups()[0]
+          term = Term(Term.REGEX_TERM, regex_token)
+        else:
+          # Rule token => store rule head.
+          term = Term(Term.RULE_TERM, body_token)
+      rule_terms.append(term)
+    return rule_terms
+
+  def __eq__(self, other):
+    """Overrides the default implementation"""
+    return self.branch_id == other.branch_id and self.body == other.body
+
+  def __repr__(self):
+    string_terms = [str(term) for term in self.body]
+    string_body = ' '.join(string_terms)
+    return string_body
 
 class Grammar:
 
   def __init__(self, grammar_str: str):
-    self.sub_rules = generate_grammar(grammar_str)
-    self.rules_by_head = generate_rules_by_head(self.sub_rules)
+    sub_rules = extract_sub_rules(grammar_str)
+    self.branches = []
+    self.rules = collections.defaultdict(list)
+    for i in range(len(sub_rules)):
+      branch_id = i
+      sub_rule = sub_rules[i]
+      head = sub_rule[0]
+      body = sub_rule[1]
+      rule_branch = RuleBranch(id=branch_id, body_str=body)
+      self.branches.append(rule_branch)
+      self.rules[head].append(branch_id)
 
-  def get_rule_by_head(self, head: str, index: int):
-    """Returns a tuple of (rule_name, rule_body) given the head, for e.g.
-    (r0, select_query)"""
-    head_rules = self.rules_by_head[head]
+  def get_branch_by_head_and_index(self, head: str, index: int):
+    """Returns the branch id given the head and index"""
+    head_rules = self.rules[head]
     return head_rules[index]
 
-  def get_rule_name_by_head(self, head: str, index: int):
-    "Returns the name of the rule (eg. r0) for the given head and index."
-    return self.get_rule_by_head(head, index)[0]
+
+if __name__ == "__main__":
+  grammar = Grammar(GRAMMAR_STR)
+  print('Branches')
+  for branch in grammar.branches:
+    print(branch)
+  print('\nRules')
+  print(grammar.rules)
+  
+        
+
+

--- a/examples/cfq/syntax-based/grammar.py
+++ b/examples/cfq/syntax-based/grammar.py
@@ -156,7 +156,7 @@ class Grammar:
       self.branches.append(rule_branch)
       self.rules[head].append(branch_id)
 
-  def get_branch_by_head_and_index(self, head: str, index: int):
+  def get_branch_id_by_head_and_index(self, head: str, index: int):
     """Returns the branch id given the head and index"""
     head_rules = self.rules[head]
     return head_rules[index]

--- a/examples/cfq/syntax-based/grammar.py
+++ b/examples/cfq/syntax-based/grammar.py
@@ -133,7 +133,7 @@ class RuleBranch:
     return rule_terms
 
   def __eq__(self, other):
-    """Overrides the default implementation"""
+    """Overrides the default implementation."""
     return self.branch_id == other.branch_id and self.body == other.body
 
   def __repr__(self):
@@ -159,16 +159,7 @@ class Grammar:
     self.grammar_entry = first_rule[0]
 
   def get_branch_id_by_head_and_index(self, head: str, index: int):
-    """Returns the branch id given the head and index"""
+    """Returns the branch id given the head and index."""
     head_rules = self.rules[head]
     return head_rules[index]
-
-
-if __name__ == "__main__":
-  grammar = Grammar(GRAMMAR_STR)
-  print('Branches')
-  for branch in grammar.branches:
-    print(branch)
-  print('\nRules')
-  print(grammar.rules)
 

--- a/examples/cfq/syntax-based/grammar_test.py
+++ b/examples/cfq/syntax-based/grammar_test.py
@@ -40,25 +40,25 @@ class GrammarTest(parameterized.TestCase):
     """
     grammar = Grammar(grammar_str)
     expected_branches = [
-      RuleBranch(0,"select_query"),
-      RuleBranch(1,"select_clause \"WHERE\" \"{\" where_clause \"}\""),
-      RuleBranch(2,"\"SELECT\" \"DISTINCT\" \"?x0\""),
-      RuleBranch(3,"\"SELECT\" \"count(*)\""),
-      RuleBranch(4,"where_entry"),
-      RuleBranch(5,"where_clause \".\" where_entry"),
-      RuleBranch(6,"triples_block"),
-      RuleBranch(7,"filter_clause"),
-      RuleBranch(8,"\"FILTER\" \"(\" var_token \"!=\" var_token \")\""),
-      RuleBranch(9,"var_token TOKEN var_token"),
-      RuleBranch(10,"VAR"),
-      RuleBranch(11,"TOKEN"),
-      RuleBranch(12,"\"?x0\""),
-      RuleBranch(13,"\"?x1\""),
-      RuleBranch(14,"\"?x2\""),
-      RuleBranch(15,"\"?x3\""),
-      RuleBranch(16,"\"?x4\""),
-      RuleBranch(17,"\"?x5\""),
-      RuleBranch(18,"/[^\s]+/")
+      RuleBranch(0, 'select_query'),
+      RuleBranch(1, 'select_clause "WHERE" "{" where_clause "}"'),
+      RuleBranch(2, '"SELECT" "DISTINCT" "?x0"'),
+      RuleBranch(3, '"SELECT" "count(*)"'),
+      RuleBranch(4, 'where_entry'),
+      RuleBranch(5, 'where_clause "." where_entry'),
+      RuleBranch(6, 'triples_block'),
+      RuleBranch(7, 'filter_clause'),
+      RuleBranch(8, '"FILTER" "(" var_token "!=" var_token ")"'),
+      RuleBranch(9, 'var_token TOKEN var_token'),
+      RuleBranch(10, 'VAR'),
+      RuleBranch(11, 'TOKEN'),
+      RuleBranch(12, '"?x0"'),
+      RuleBranch(13, '"?x1"'),
+      RuleBranch(14, '"?x2"'),
+      RuleBranch(15, '"?x3"'),
+      RuleBranch(16, '"?x4"'),
+      RuleBranch(17, '"?x5"'),
+      RuleBranch(18, '/[^\s]+/')
     ]
     expected_rules = {
       'query': [0], 'select_query': [1], 'select_clause': [2, 3],
@@ -80,11 +80,11 @@ class GrammarTest(parameterized.TestCase):
     """
     grammar = Grammar(grammar_str)
     expected_branches = [
-      RuleBranch(0, "b"),
-      RuleBranch(1, "c"),
-      RuleBranch(2, "d"),
-      RuleBranch(3, "\"some_token\""),
-      RuleBranch(4, "\"some_other_token\""),
+      RuleBranch(0, 'b'),
+      RuleBranch(1, 'c'),
+      RuleBranch(2, 'd'),
+      RuleBranch(3, '"some_token"'),
+      RuleBranch(4, '"some_other_token"'),
     ]
     expected_rules = {
       'a': [0],

--- a/examples/cfq/syntax-based/node.py
+++ b/examples/cfq/syntax-based/node.py
@@ -69,6 +69,7 @@ def apply_action(frontier_nodes_stack: deque, action: Action, grammar: Grammar):
 def construct_root(grammar: Grammar):
   return Node(None, grammar.grammar_entry)
 
+
 def apply_sequence_of_actions(action_sequence: List, grammar: Grammar):
   """Applies a sequence of actions to construct a syntax tree."""
   root = construct_root(grammar)

--- a/examples/cfq/syntax-based/node.py
+++ b/examples/cfq/syntax-based/node.py
@@ -49,7 +49,7 @@ def apply_action(frontier_nodes_stack: deque, action: Action, grammar: Grammar):
     # Generate leaf node with token stored in the action.
     child = Node(current_node, action_value)
     current_node.add_child(child)
-    # A terminal node has only one branh. Set the id of that.
+    # A terminal node has only one branch. Set the id of that.
     rule_id = grammar.get_branch_id_by_head_and_index(current_node.value, 0)
     current_node.set_rule_id(rule_id)
   else:

--- a/examples/cfq/syntax-based/node.py
+++ b/examples/cfq/syntax-based/node.py
@@ -17,20 +17,24 @@
 
 import re
 from typing import List
-from grammar import Grammar, GRAMMAR_STR
+from grammar import Grammar, GRAMMAR_STR, TermType
 from asg import generate_action_sequence
 from collections import deque
 from asg import Action, APPLY_RULE, GENERATE_TOKEN
-
 class Node:
 
   def __init__(self, parent: 'Node', value: str):
     self.parent = parent
     self.value = value
     self.children = []
+    # id of rule expanded at this node.
+    self.rule_id = None
 
   def add_child(self, child: 'Node'):
     self.children.append(child)
+
+  def set_rule_id(self, id: int):
+    self.rule_id = id
 
   def __repr__(self):
     return self.value
@@ -45,61 +49,57 @@ def apply_action(frontier_nodes_stack: deque, action: Action, grammar: Grammar):
     # Generate leaf node with token stored in the action.
     child = Node(current_node, action_value)
     current_node.add_child(child)
+    # A terminal node has only one branh. Set the id of that.
+    rule_id = grammar.get_branch_id_by_head_and_index(current_node.value, 0)
+    current_node.set_rule_id(rule_id)
   else:
+    current_node.set_rule_id(action_value)
     new_frontier_nodes = []
-    head, body = grammar.sub_rules[action_value]
-    if head != current_node.value:
-      raise Exception('Invalid action. Got {} and expected {}'.format(
-          head, current_node.value))
-    rule_tokens = body.split()
-    for rule_token in rule_tokens:
-      match = re.match(r'\"(.*)\"', rule_token)
-      if match:
-        # Create a leaf node with a token from the rule (e.g. SELECT).
-        node_value = match.groups()[0]
-        child = Node(current_node, node_value)
-      else:
-        # Create new frontier node.
-        child = Node(current_node, rule_token)
+    rule_branch = grammar.branches[action_value]
+    for term in rule_branch.body:
+      if term.term_type == TermType.RULE_TERM:
+        child = Node(current_node, term.value)
         new_frontier_nodes.append(child)
-      current_node.add_child(child)
+        current_node.add_child(child)
     new_frontier_nodes.reverse()
     frontier_nodes_stack.extend(new_frontier_nodes)
   return frontier_nodes_stack
 
 
-def apply_first_action(action: Action, grammar: Grammar):
-  """Applies the first action in the sequence of actions and constructs the
-  tree root."""
-  action_type, action_value = action
-  if action_type != APPLY_RULE:
-    raise Exception('First action should be rule application')
-  _, node_value = grammar.sub_rules[action_value]
-  root = Node(None, node_value)
-  return root
-
+def construct_root(grammar: Grammar):
+  return Node(None, grammar.grammar_entry)
 
 def apply_sequence_of_actions(action_sequence: List, grammar: Grammar):
   """Applies a sequence of actions to construct a syntax tree."""
-  root = apply_first_action(action_sequence[0], grammar)
+  root = construct_root(grammar)
   frontier_nodes = deque()
   frontier_nodes.append(root)
-  for action in action_sequence[1:]:
+  for action in action_sequence:
     frontier_nodes = apply_action(frontier_nodes, action, grammar)
   return root
 
 
-def traverse_tree(root: Node):
+def extract_query(root: Node, grammar: Grammar):
   """DFS traversal of tree. The result of the traversal should be the query. In
   case the parent node is a terminal, the descendents will be simply
   concatenated, e.g. VAR, otherwise the substrings are merged together by spaces.
+  When rule nodes are being visited, the grammar rule is traversed and the syntax
+  tokens are added, besides visiting the children nodes in the AST.
   """
-  if len(root.children) == 0:
+  if root.rule_id is None:
+    # leaf/token node
     return root.value
   children_substrings = []
-  for child in root.children:
-    child_substr = traverse_tree(child)
-    children_substrings.append(child_substr)
+  rule_branch = grammar.branches[root.rule_id]
+  child_idx = 0
+  for term in rule_branch.body:
+    if term.term_type == TermType.SYNTAX_TERM:
+      children_substrings.append(term.value)
+    else:
+      child_node = root.children[child_idx]
+      child_substr = extract_query(child_node, grammar)
+      children_substrings.append(child_substr)
+      child_idx += 1
   if root.value.isupper():
     delimiter = ''
   else:
@@ -115,5 +115,7 @@ if __name__ == "__main__":
   grammar = Grammar(GRAMMAR_STR)
   generated_action_sequence = generate_action_sequence(query, grammar)
   root = apply_sequence_of_actions(generated_action_sequence, grammar)
-  query = traverse_tree(root)
+  query = extract_query(root, grammar)
   print(query)
+
+


### PR DESCRIPTION
Changes in this PR:
* grammar representation was changed so that the grammar rules do not have to be parsed as strings when the tree is constructed
* the action sequence generation was modified to work with new grammar representation
* when applying the actions an AST not an CST is generated and the query is extracted from the AST (can be done in post processing) using the information from the grammar as well, not just the tree nodes (the AST does not contain syntax nodes)