### PR TITLE
Cfq vmap decoder

### DIFF
--- a/examples/cfq/cfq_main.py
+++ b/examples/cfq/cfq_main.py
@@ -98,6 +98,7 @@ def main(_):
   if FLAGS.syntax_based:
     train_fn = train_syntax_based.train_model
     test_fn = train_syntax_based.test_model
+    #TODO: replace with Seq2Tree once model ready.
     data_source = inp.Seq2SeqCfqDataSource(
       seed=FLAGS.seed,
       fixed_output_len=False,

--- a/examples/cfq/models.py
+++ b/examples/cfq/models.py
@@ -424,7 +424,7 @@ class SyntaxBasedDecoder(nn.Module):
         train=train)
 
     time_steps = inputs.shape[0]
-    initial_h = init_states[-1,1,:]
+    initial_h = init_states[-1, 1, :]
     multilayer_lstm_output = (init_states, initial_h)
     carry = (nn.make_rng(), multilayer_lstm_output, inputs[0])
     all_logits = []

--- a/examples/cfq/models.py
+++ b/examples/cfq/models.py
@@ -500,47 +500,6 @@ class SyntaxBasedDecoder(nn.Module):
 
     all_scores = jnp.array(all_scores)
     all_scores = jnp.swapaxes(all_scores, 0, 1)
-    # def decode_step_fn(carry, x):
-    #   rng, multilayer_lstm_output, last_prediction = carry
-    #   previous_states, h = multilayer_lstm_output
-    #   carry_rng, categorical_rng = jax.random.split(rng, 2)
-    #   if not train:
-    #     x = last_prediction
-    #   x = shared_embedding(x)
-    #   x = nn.dropout(x, rate=embed_dropout_rate, deterministic=train)
-    #   dec_prev_state = jnp.expand_dims(h, 1)
-    #   context, scores = mlp_attention(dec_prev_state, projected_keys,
-    #                                   encoder_hidden_states, attention_mask)
-    #   lstm_input = jnp.concatenate([x, context], axis=-1)
-    #   states, h = multilayer_lstm_cell(
-    #     horizontal_dropout_masks=h_dropout_masks,
-    #     vertical_dropout_rate=vertical_dropout_rate,
-    #     input=lstm_input,
-    #     previous_states=previous_states,
-    #     train=train)
-    #   logits = projection(h)
-    #   predicted_tokens = jax.random.categorical(categorical_rng, logits)
-    #   predicted_tokens_uint8 = jnp.asarray(predicted_tokens, dtype=jnp.uint8)
-    #   new_carry = (carry_rng, (states, h), predicted_tokens_uint8)
-    #   new_x = (logits, predicted_tokens_uint8, scores)
-    #   return new_carry, new_x
-
-    # initialisig the LSTM states and final output with the
-    # encoder hidden states
-    # multilayer_lstm_output = (init_states, init_states[-1][1])
-    # init_carry = (nn.make_rng(), multilayer_lstm_output, inputs[:, 0])
-
-    # if self.is_initializing():
-    #   # initialize parameters before scan -- why?
-    #   decode_step_fn(init_carry, inputs[:, 0])
-
-    # _, (logits, predictions, scores) = jax_utils.scan_in_dim(
-    #     decode_step_fn,
-    #     init=init_carry,  # rng, lstm_state, last_pred
-    #     xs=inputs,
-    #     axis=1)
-    # The attention weights are only examined on the evaluation flow, so this
-    # if is used to avoid unnecesary operations.
     if not self.is_initializing() and not train:
       attention_weights = jnp.array(all_scores)
       # Going from [output_seq_len, batch_size, input_seq_len]

--- a/examples/cfq/models_test.py
+++ b/examples/cfq/models_test.py
@@ -6,7 +6,8 @@ import jax.numpy as jnp
 from flax import nn
 
 import models
-from models import Encoder, MlpAttention, Decoder, Seq2seq, MultilayerLSTM
+from models import Encoder, MlpAttention, Decoder, Seq2seq, MultilayerLSTM,\
+  Seq2tree
 
 
 class ModelsTest(parameterized.TestCase):
@@ -201,6 +202,33 @@ class ModelsTest(parameterized.TestCase):
     input_length = 3
     predicted_length = 4
     seq2seq = Seq2seq.partial(vocab_size=vocab_size)
+    with nn.stochastic(jax.random.PRNGKey(0)):
+      _, initial_params = models.Seq2seq.partial(vocab_size=vocab_size
+                            ).init_by_shape(nn.make_rng(),
+                            [((1, 1), jnp.uint8),
+                              ((1, 2), jnp.uint8),
+                              ((1,), jnp.uint8)])
+      model = nn.Model(models.Seq2seq, initial_params)
+      logits, predictions, attention_weights = model(encoder_inputs=enc_inputs,
+                                                 decoder_inputs=dec_inputs,
+                                                 encoder_inputs_lengths=lengths,
+                                                 vocab_size=vocab_size,
+                                                 train=False)
+      self.assertEqual(logits.shape, (batch_size, max_len - 1, vocab_size))
+      self.assertEqual(predictions.shape, (batch_size, max_len - 1))
+      self.assertEqual(
+        attention_weights.shape, (batch_size, predicted_length, input_length))
+
+  def test_seq_2_tree_inference_apply(self):
+    vocab_size = 10
+    batch_size = 2
+    max_len = 5
+    enc_inputs = jnp.array([[1, 0, 2], [1, 4, 2]], dtype=jnp.uint8)
+    lengths = jnp.array([2, 3])
+    dec_inputs = jnp.array([[6, 7, 3, 5, 1], [1, 4, 2, 3, 2]], dtype=jnp.uint8)
+    input_length = 3
+    predicted_length = 4
+    seq2seq = Seq2tree.partial(vocab_size=vocab_size)
     with nn.stochastic(jax.random.PRNGKey(0)):
       _, initial_params = models.Seq2seq.partial(vocab_size=vocab_size
                             ).init_by_shape(nn.make_rng(),


### PR DESCRIPTION
With these changes the seq2tree modules were prepared to make future changes simpler, but for now the code still runs in a seq2seq setting.

`SyntaxBasedDecoder` was modified and is now different from `Decoder` in two ways:
* a `for` loop is used accross the time steps instead of `scan_in_dim`
* the code in the `SyntaxBasedDecoder` is written at batch level and it's **vmapped** inside `Seq2tree`

The new modules were **tested** in the seq2seq setting (on a single gpu machine, with batch size 256, for 1500 steps and evaluatione done every 100 steps). The results for the old and new modules are:
* old modules
  * time until first result: 4 min (dataset loading & jitting)
  * time per 100 steps: ~20 s
  * accuracy: ~50% (run1 44%, run2 55%)
* new modules:
  * time until first result: 20 min
  * time per 100 steps: ~20 s
  * accuracy: 50% (only one run)
